### PR TITLE
Add messages to save-state load

### DIFF
--- a/javascript/src/seedsource-ui/config.ts
+++ b/javascript/src/seedsource-ui/config.ts
@@ -666,13 +666,29 @@ export const regions = [
 
 export const regionsBoundariesUrl = '/static/geometry/regions.topojson'
 
-export const saveVersion = 2 // Next version should add +1 (must be a larger integer). When updating save version,
+export const saveVersion = 3 // Next version should add +1 (must be a larger integer). When updating save version,
 // also add to `migrations` below.
 
 // `version` is the version you are migrating *from*.
-export const migrations: { version: number; migrate: (configuration: any) => { configuration: any } }[] = [
+export const migrations: {
+  version: number
+  migrate: (configuration: any) => { configuration: any }
+  message: string
+}[] = [
   {
     version: 1,
     migrate: (configuration: any) => ({ ...configuration, customMode: false }),
+    message: '',
+  },
+  {
+    version: 2,
+    migrate: (configuration: any) => {
+      const defaultClimate = {
+        seedlot: { time: '1961_1990', model: null },
+        site: { time: '1961_1990', model: 'ssp245' },
+      }
+      return { ...configuration, climate: defaultClimate }
+    },
+    message: t`The climate model data in your save is outdated. To resolve this issue, please select a new climate scenario.`,
   },
 ]

--- a/javascript/src/seedsource-ui/containers/SavedRun.tsx
+++ b/javascript/src/seedsource-ui/containers/SavedRun.tsx
@@ -1,9 +1,10 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { connect, ConnectedProps } from 'react-redux'
 import { t, c } from 'ttag'
 import { loadConfiguration, resetConfiguration, deleteSave } from '../actions/saves'
 import { migrateConfiguration } from '../utils'
 import ShareURL from '../components/ShareURL'
+import ModalCard from '../components/ModalCard'
 
 const connector = connect(null, (dispatch: (event: any) => any, { onClick }: { onClick: () => any }) => {
   return {
@@ -11,10 +12,8 @@ const connector = connect(null, (dispatch: (event: any) => any, { onClick }: { o
       onClick()
     },
 
-    onLoad: (save: any) => {
+    onLoad: (migratedConfiguration: any, save: any) => {
       dispatch(resetConfiguration())
-      const migratedConfiguration = migrateConfiguration(save.configuration, save.version)
-
       /* In some cases where the loaded configuration is similar to the previous one, certain events aren't
        * fired if the event is dispatched in the same event cycle as the reset event
        */
@@ -34,49 +33,99 @@ type SavedRunProps = ConnectedProps<typeof connector> & {
 
 const SavedRun = ({ active, save, onClick, onLoad, onDelete }: SavedRunProps) => {
   let className = 'configuration-item'
+  let modal = null
   const { modified, title } = save
+  const [modalToShow, setModalToShow] = useState<string>('')
+  const [messages, setMessages] = useState<string[]>([])
+  const [migratedConfiguration, setMigratedConfiguration] = useState<any>({})
 
   if (active) {
     className += ' focused'
   }
 
-  return (
-    <div
-      className={className}
-      onClick={() => {
-        onClick()
-      }}
-    >
-      <div className="save-title">{title}</div>
-      <div className="save-date">
-        {t`Last modified:`} {modified.getMonth() + 1}/{modified.getDate()}/{modified.getYear()}
+  if (modalToShow === 'confirm') {
+    const footer = (
+      <div style={{ width: '100%' }}>
+        <button type="button" className="button" onClick={() => setModalToShow('')}>
+          {t`Cancel`}
+        </button>
+        <button
+          type="button"
+          className="button is-primary is-pulled-right"
+          onClick={() => {
+            const migration = migrateConfiguration(save.configuration, save.version)
+            setMessages(migration.messages)
+            setMigratedConfiguration(migration.migratedConfiguration)
+            setModalToShow('messages')
+          }}
+        >
+          {t`Confirm`}
+        </button>
       </div>
-      <div className="buttons">
-        <ShareURL configuration={save.configuration} version={save.version} />
+    )
+    modal = (
+      <ModalCard
+        title={t`Load configuration?`}
+        active={modalToShow === 'confirm'}
+        onHide={() => setModalToShow('')}
+        footer={footer}
+      >
+        {t`Loading this configuration will replace your current settings.`}
+      </ModalCard>
+    )
+  }
 
-        <div>
-          <button
-            type="button"
-            onClick={() => {
-              if (window.confirm(t`Load this saved configuration? This will replace your current settings.`)) {
-                onLoad(save)
-              }
-            }}
-            className="button is-primary"
-          >
-            <span className="icon-load-12" aria-hidden="true" /> &nbsp;{c('e.g., Load file').t`Load`}
-          </button>
-          <button
-            type="button"
-            onClick={() => {
-              if (window.confirm(t`Delete this saved configuration?`)) {
-                onDelete(save.uuid)
-              }
-            }}
-            className="button is-danger"
-          >
-            <span className="icon-trash-12" aria-hidden="true" /> &nbsp;{t`Delete`}
-          </button>
+  if (modalToShow === 'messages') {
+    const text = messages.map(message => <li>{message}</li>)
+    const onHide = () => {
+      onLoad(migratedConfiguration, save)
+      setModalToShow('')
+    }
+    const footer = (
+      <div style={{ width: '100%' }}>
+        <button type="button" onClick={onHide} className="button is-primary is-pulled-right">{t`OK`}</button>
+      </div>
+    )
+    modal = (
+      <ModalCard title={t`Notification`} active={modalToShow === 'messages'} onHide={onHide} footer={footer}>
+        <div>{t`The following issue(s) were encountered while loading your saved run.`}</div>
+        <ul>{text}</ul>
+      </ModalCard>
+    )
+  }
+
+  return (
+    <div>
+      {modal}
+      <div
+        className={className}
+        onClick={() => {
+          onClick()
+        }}
+      >
+        <div className="save-title">{title}</div>
+        <div className="save-date">
+          {t`Last modified:`} {modified.getMonth() + 1}/{modified.getDate()}/{modified.getYear()}
+        </div>
+        <div className="buttons">
+          <ShareURL configuration={save.configuration} version={save.version} />
+
+          <div>
+            <button type="button" onClick={() => setModalToShow('confirm')} className="button is-primary">
+              <span className="icon-load-12" aria-hidden="true" /> &nbsp;{c('e.g., Load file').t`Load`}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                if (window.confirm(t`Delete this saved configuration?`)) {
+                  onDelete(save.uuid)
+                }
+              }}
+              className="button is-danger"
+            >
+              <span className="icon-trash-12" aria-hidden="true" /> &nbsp;{t`Delete`}
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/javascript/src/seedsource-ui/utils.ts
+++ b/javascript/src/seedsource-ui/utils.ts
@@ -82,13 +82,17 @@ export const getZoneLabel = (zone?: any) => {
 }
 
 export const migrateConfiguration = (configuration: any, version: number) => {
-  let updatedConfiguration = configuration
+  let migratedConfiguration = configuration
+  const messages: string[] = []
 
   for (let i = version; i < saveVersion; i += 1) {
     const migration = migrations.find(m => m.version === i)
     if (migration) {
-      updatedConfiguration = migration.migrate(updatedConfiguration)
+      migratedConfiguration = migration.migrate(migratedConfiguration)
+      if (migration.message) {
+        messages.push(migration.message)
+      }
     }
   }
-  return updatedConfiguration
+  return { migratedConfiguration, messages }
 }


### PR DESCRIPTION
Resolves SST-128

Also updates the load save-state confirmation from an alert to a modal.

Clicking **Load** here:
<img width="520" height="204" alt="image" src="https://github.com/user-attachments/assets/bbf9d76b-2e2d-4745-897e-dd6272f7c006" />

now displays the following instead of an alert:
<img width="665" height="242" alt="image" src="https://github.com/user-attachments/assets/aa13dbe2-4265-477d-8184-6883b931e83e" />

Clicking **Confirm** will load the configuration and show load messages:
<img width="659" height="296" alt="image" src="https://github.com/user-attachments/assets/0567190b-5138-48ce-97e6-164992186902" />

