### PR TITLE
Update trefoil & ncdjango

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1562,32 +1562,28 @@ name = "ncdjango"
 version = "1.3.7"
 description = "A NetCDF mapserver app for Django"
 optional = false
-python-versions = ">=3.10,<3.11"
+python-versions = "<3.11,>=3.10"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "ncdjango-1.3.7-py3-none-any.whl", hash = "sha256:4c05703fcade45ef773b8be1f0bfd313211118aad92852fb582627261cbc77ae"},
+    {file = "ncdjango-1.3.7.tar.gz", hash = "sha256:13e72739a96e4a2707c306bf5345aabaec73764dc9ecae4ad35589c57ccf0562"},
+]
 
 [package.dependencies]
-celery = "^5.2.3"
+celery = ">=5.2.3,<6.0.0"
 Django = ">=5.2.0"
-django-tastypie = "^0.14.0"
+django-tastypie = ">=0.14.0,<0.15.0"
 djangorestframework = "*"
 Fiona = "*"
 netCDF4 = ">=1.5.3"
-numpy = "^1.24"
-Pillow = "^9.0.1"
+numpy = ">=1.24,<2.0"
+Pillow = ">=9.0.1,<10.0.0"
 ply = "*"
 pyproj = "*"
 rasterio = "*"
 requests = "*"
 Shapely = ">=1.7.0"
 trefoil = "0.4.0"
-
-[package.source]
-type = "git"
-url = "https://github.com/consbio/ncdjango.git"
-reference = "1.3.7"
-resolved_reference = "9ae286497dd4058744bc98d66c11e44c09a699f9"
 
 [[package]]
 name = "netcdf4"
@@ -2520,10 +2516,12 @@ name = "trefoil"
 version = "0.4.0"
 description = "Geospatial operations with NetCDF files and numpy arrays."
 optional = false
-python-versions = ">=3.9,<3.12"
+python-versions = "<3.12,>=3.9"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "trefoil-0.4.0-py3-none-any.whl", hash = "sha256:cecedf8746911ee5efc48838c572c5dbfa5c5ec0349b0e1016cebb2b0d3bcd1d"},
+    {file = "trefoil-0.4.0.tar.gz", hash = "sha256:19eca8984eabb1d126bb3b8aa2c3432c2ebe6d3c4fec5bf3d5b48e4456c5d227"},
+]
 
 [package.dependencies]
 affine = ">=1.0"
@@ -2533,17 +2531,11 @@ jinja2 = "*"
 netcdf4 = ">=1.1.1"
 numpy = "*"
 palettable = "*"
-pillow = "^9.0.1"
+pillow = ">=9.0.1,<10.0.0"
 pyproj = "*"
 pytz = "*"
-rasterio = "^1.4.3"
-six = "^1.17.0"
-
-[package.source]
-type = "git"
-url = "https://github.com/consbio/trefoil.git"
-reference = "0.4.0"
-resolved_reference = "f1438ee6ed29afb818b7b77a4b5315915edc2717"
+rasterio = ">=1.4.3,<2.0.0"
+six = ">=1.17.0,<2.0.0"
 
 [[package]]
 name = "typing-extensions"
@@ -2784,4 +2776,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.11"
-content-hash = "fd4ed9d27aef25fb771e708e20f764f159426423e908fda81aadc1ad224f69f5"
+content-hash = "df735b38c947831366e40f8472a2f01ec2a2cefcd63918527e1f08f542b9f97a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ package-mode = false
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.11"
-trefoil = { git = "https://github.com/consbio/trefoil.git", tag = "0.4.0" }
+trefoil = "^0.4.0"
 rasterio = "^1.2a1"
 django-celery-results = "^2.0.0"
 social-auth-app-django = "^5.0.0"
@@ -18,7 +18,7 @@ celery = "^5.2.3"
 pyproj = "^3.6.1"
 sentry-sdk = "^1.45.1"
 enmerkar = "^0.7.1"
-ncdjango = { git = "https://github.com/consbio/ncdjango.git", tag = "1.3.7" }
+ncdjango = "^1.3.7"
 aiohttp = "^3.12.14"
 Django = "^5.2"
 djangorestframework = "~3.14"


### PR DESCRIPTION
This updates trefoil & ncdjango to the latest versions and targets the versions by tag rather than branch as it is a bit more transparent.