### PR TITLE
Fix legends

### DIFF
--- a/javascript/src/seedsource-ui/actions/legends.ts
+++ b/javascript/src/seedsource-ui/actions/legends.ts
@@ -46,7 +46,7 @@ export const receiveLayersLegend = (json: any) => {
   })
 
   return {
-    type: REQUEST_LAYERS_LEGEND,
+    type: RECEIVE_LAYERS_LEGEND,
     legend,
     layerName,
   }


### PR DESCRIPTION
Resolves SST-133 and fixes legends more generally. This probably doesn't need a review, but at some point the words `RECEIVE` and `REQUEST` were swapped, breaking legend functionality.

Here's how it looks fixed:
<img width="1011" height="417" alt="image" src="https://github.com/user-attachments/assets/ebc21548-32ac-4049-a273-b2fd03fd312e" />
