### PR TITLE
Move People logos to About tab

### DIFF
--- a/javascript/src/components/About.tsx
+++ b/javascript/src/components/About.tsx
@@ -8,6 +8,10 @@ import ClimateImage from '../../images/about_climate.gif'
 import MethodImage from '../../images/about_method.gif'
 import VariablesImage from '../../images/about_variables.gif'
 import MapImage from '../../images/about_map.gif'
+import FSLogo from '../../images/fs_logo.png'
+import OSULogo from '../../images/osu_logo.png'
+import CBILogo from '../../images/cbi_logo.png'
+import ClimateHubLogo from '../../images/nw_climate_hub_logo.png'
 
 const About = () => (
   <div>
@@ -57,6 +61,29 @@ const About = () => (
         <img src={MapImage} alt={t`An icon of the globe`} />
         <h4 className="title is-4">7. {t`Map your Results`}</h4>
         <p>{t`The map shows where to find appropriate seedlots or planting sites`}</p>
+      </div>
+    </div>
+    <hr />
+    <div className="columns">
+      <div className="column">
+        <a href="http://www.fs.fed.us/" target="_blank" rel="noreferrer">
+          <img src={FSLogo} alt={t`United States Forest Service`} />
+        </a>
+      </div>
+      <div className="column">
+        <a href="http://oregonstate.edu/" target="_blank" rel="noreferrer">
+          <img src={OSULogo} alt={t`Oregon State University`} />
+        </a>
+      </div>
+      <div className="column">
+        <a href="http://consbio.org" target="_blank" rel="noreferrer">
+          <img src={CBILogo} alt={t`Conservation Biology Institute`} />
+        </a>
+      </div>
+      <div className="column is-half">
+        <a href="https://www.climatehubs.oce.usda.gov/hubs/northwest" target="_blank" rel="noreferrer">
+          <img src={ClimateHubLogo} alt={t`NW Climate Hub`} />
+        </a>
       </div>
     </div>
   </div>

--- a/javascript/src/components/Menu.tsx
+++ b/javascript/src/components/Menu.tsx
@@ -5,10 +5,6 @@ import NavItemDropdown from '../seedsource-ui/components/NavItemDropdown'
 import { getCookies } from '../seedsource-ui/utils'
 import Background1 from '../../images/background1.jpg'
 import Background2 from '../../images/background2.jpg'
-import FSLogo from '../../images/fs_logo.png'
-import OSULogo from '../../images/osu_logo.png'
-import CBILogo from '../../images/cbi_logo.png'
-import ClimateHubLogo from '../../images/nw_climate_hub_logo.png'
 import SSTInstructions from '../../documents/SST User Guide.pdf'
 import SSTInstructionsESMX from '../../documents/translations/es_MX/SST User Guide.pdf'
 import SSTSilviculturistsGuide from '../../documents/SST R6 Silviculturists Guide.pdf'
@@ -402,29 +398,6 @@ class Menu extends React.Component {
                 Conservation Biology Institute, the USDA Northwest Climate Hub, Natural Resources Canada, 
                 USFS International Programs, and USFS State & Private`}
             </p>
-            <p>&nbsp;</p>
-            <div className="columns">
-              <div className="column">
-                <a href="http://www.fs.fed.us/" target="_blank" rel="noreferrer">
-                  <img src={FSLogo} alt={t`United States Forest Service`} />
-                </a>
-              </div>
-              <div className="column">
-                <a href="http://oregonstate.edu/" target="_blank" rel="noreferrer">
-                  <img src={OSULogo} alt={t`Oregon State University`} />
-                </a>
-              </div>
-              <div className="column">
-                <a href="http://consbio.org" target="_blank" rel="noreferrer">
-                  <img src={CBILogo} alt={t`Conservation Biology Institute`} />
-                </a>
-              </div>
-              <div className="column is-half">
-                <a href="https://www.climatehubs.oce.usda.gov/hubs/northwest" target="_blank" rel="noreferrer">
-                  <img src={ClimateHubLogo} alt={t`NW Climate Hub`} />
-                </a>
-              </div>
-            </div>
             <p>&nbsp;</p>
             <h4 className="title is-4">{t`Contact Information`}</h4>
             <p>


### PR DESCRIPTION
Resolves SST-134

Moves  logos from People modal to About tab.

People modal (sans logos):
<img width="493" height="641" alt="image" src="https://github.com/user-attachments/assets/6690c861-6872-4751-8f91-e0c421562850" />

About tab:
<img width="394" height="381" alt="image" src="https://github.com/user-attachments/assets/82ec0848-080e-4521-bb9c-c426059c46a6" />
