### PR TITLE
Support use of aws secrets manager for settings

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -246,6 +246,46 @@ files = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.40.1"
+description = "The AWS SDK for Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "boto3-1.40.1-py3-none-any.whl", hash = "sha256:7c007d5c8ee549e9fcad0927536502da199b27891006ef515330f429aca9671f"},
+    {file = "boto3-1.40.1.tar.gz", hash = "sha256:985ed4bf64729807f870eadbc46ad98baf93096917f7194ec39d743ff75b3f1d"},
+]
+
+[package.dependencies]
+botocore = ">=1.40.1,<1.41.0"
+jmespath = ">=0.7.1,<2.0.0"
+s3transfer = ">=0.13.0,<0.14.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
+
+[[package]]
+name = "botocore"
+version = "1.40.1"
+description = "Low-level, data-driven core of boto 3."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "botocore-1.40.1-py3-none-any.whl", hash = "sha256:e039774b55fbd6fe59f0f4fea51d156a2433bd4d8faa64fc1b87aee9a03f415d"},
+    {file = "botocore-1.40.1.tar.gz", hash = "sha256:bdf30e2c0e8cdb939d81fc243182a6d1dd39c416694b406c5f2ea079b1c2f3f5"},
+]
+
+[package.dependencies]
+jmespath = ">=0.7.1,<2.0.0"
+python-dateutil = ">=2.1,<3.0.0"
+urllib3 = {version = ">=1.25.4,<2.2.0 || >2.2.0,<3", markers = "python_version >= \"3.10\""}
+
+[package.extras]
+crt = ["awscrt (==0.23.8)"]
+
+[[package]]
 name = "cairocffi"
 version = "1.7.1"
 description = "cffi-based cairo bindings for Python"
@@ -1167,6 +1207,18 @@ MarkupSafe = ">=2.0"
 i18n = ["Babel (>=2.7)"]
 
 [[package]]
+name = "jmespath"
+version = "1.0.1"
+description = "JSON Matching Expressions"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980"},
+    {file = "jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"},
+]
+
+[[package]]
 name = "kombu"
 version = "5.5.3"
 description = "Messaging library for Python."
@@ -1989,7 +2041,6 @@ files = [
     {file = "psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:bb89f0a835bcfc1d42ccd5f41f04870c1b936d8507c6df12b7737febc40f0909"},
     {file = "psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f0c2d907a1e102526dd2986df638343388b94c33860ff3bbe1384130828714b1"},
     {file = "psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f8157bed2f51db683f31306aa497311b560f2265998122abe1dce6428bd86567"},
-    {file = "psycopg2_binary-2.9.10-cp313-cp313-win_amd64.whl", hash = "sha256:27422aa5f11fbcd9b18da48373eb67081243662f9b46e6fd07c3eb46e4535142"},
     {file = "psycopg2_binary-2.9.10-cp38-cp38-macosx_12_0_x86_64.whl", hash = "sha256:eb09aa7f9cecb45027683bb55aebaaf45a0df8bf6de68801a6afdc7947bb09d4"},
     {file = "psycopg2_binary-2.9.10-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b73d6d7f0ccdad7bc43e6d34273f70d587ef62f824d7261c4ae9b8b1b6af90e8"},
     {file = "psycopg2_binary-2.9.10-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ce5ab4bf46a211a8e924d307c1b1fcda82368586a19d0a24f8ae166f5c784864"},
@@ -2286,6 +2337,24 @@ requests = ">=2.0.0"
 
 [package.extras]
 rsa = ["oauthlib[signedtoken] (>=3.0.0)"]
+
+[[package]]
+name = "s3transfer"
+version = "0.13.1"
+description = "An Amazon S3 Transfer Manager"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "s3transfer-0.13.1-py3-none-any.whl", hash = "sha256:a981aa7429be23fe6dfc13e80e4020057cbab622b08c0315288758d67cabc724"},
+    {file = "s3transfer-0.13.1.tar.gz", hash = "sha256:c3fdba22ba1bd367922f27ec8032d6a1cf5f10c934fb5d68cf60fd5a23d936cf"},
+]
+
+[package.dependencies]
+botocore = ">=1.37.4,<2.0a.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.37.4,<2.0a.0)"]
 
 [[package]]
 name = "sentry-sdk"
@@ -2776,4 +2845,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.11"
-content-hash = "df735b38c947831366e40f8472a2f01ec2a2cefcd63918527e1f08f542b9f97a"
+content-hash = "f9b8c853e0b062ea392d3915a73c9f764414f06b64ca5889a6b7072f84bb71c9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ python-pptx = "^0.6.21"
 WeasyPrint = "^52.2"
 django-waffle = "^2.2"
 django-filter = "^25.1"
+boto3 = "^1.40.1"
 
 [poetry.group.dev.dependencies]
 

--- a/source/sst_project/settings/base.py
+++ b/source/sst_project/settings/base.py
@@ -1,4 +1,3 @@
-import json
 import os
 
 import random
@@ -11,19 +10,14 @@ from django.utils.translation import gettext_lazy as _
 from trefoil.render.renderers.stretched import StretchedRenderer
 from trefoil.utilities.color import Color
 
+from .config import Config
 
 # Starting at this file, walk back up the directory tree to the project root
 BASE_DIR = os.path.abspath(__file__)
 for __ in range(4):
     BASE_DIR = os.path.dirname(BASE_DIR)
 
-CONFIG = {}
-config_file = os.environ.get("SEEDSOURCE_CONF_FILE") or os.path.join(
-    BASE_DIR, "config.json"
-)
-if config_file and os.path.isfile(config_file):
-    with open(config_file) as f:
-        CONFIG = json.loads(f.read())
+CONFIG = Config.get_instance()
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = CONFIG.get(

--- a/source/sst_project/settings/config.py
+++ b/source/sst_project/settings/config.py
@@ -1,0 +1,67 @@
+import json
+import os
+from pathlib import Path
+
+import boto3
+
+
+class Config:
+    @staticmethod
+    def secrets_manager():
+        """Load config from AWS Systems Manager parameter store"""
+
+        return SecretsManagerConfig()
+
+    @staticmethod
+    def json():
+        """Load config form local `config.json` file"""
+
+        return JSONConfig()
+
+    @staticmethod
+    def get_instance():
+        """Get the appropriate config for the environment"""
+
+        is_production = bool(os.environ.get("AWS_SECRETS_KEY"))
+
+        if is_production:
+            return Config.secrets_manager()
+        else:
+            return Config.json()
+
+    def __init__(self):
+        self.items = {}
+
+    def __getitem__(self, item):
+        return self.items[item]
+
+    def get(self, item, default=None):
+        return self.items.get(item, default)
+
+
+class SecretsManagerConfig(Config):
+    def __init__(self):
+        super().__init__()
+
+        secrets_key = os.environ.get("AWS_SECRETS_KEY")
+        if not secrets_key:
+            raise ValueError("Environment variable AWS_SECRETS_KEY must be set")
+
+        client = boto3.client("secretsmanager")
+        value = client.get_secret_value(SecretId=secrets_key)
+
+        self.items = json.loads(value["SecretString"])
+
+
+class JSONConfig(Config):
+    def __init__(self):
+        super().__init__()
+
+        base_dir = Path(__file__).parent.parent.parent.parent
+        config_file = os.environ.get("SEEDSOURCE_CONF_FILE") or base_dir / "config.json"
+
+        try:
+            with open(config_file) as f:
+                self.items = json.loads(f.read())
+        except FileNotFoundError:
+            self.items = {}


### PR DESCRIPTION
This PR modifies the source of secrets and environment-specific values used in `settings.py`. A `config.json` file will continue to work for local development, but production will now obtain these values from AWS Secrets Manager. In addition to better handling of secrets, this will make it easier to update secrets and configuration, as well as launch replacement servers (since it won't be necessary to login to the server and setup the `config.json`).